### PR TITLE
Fix bug with "all" MHC option

### DIFF
--- a/R/antigen.garnish_assemble.R
+++ b/R/antigen.garnish_assemble.R
@@ -65,7 +65,7 @@ detect_mhc <- function(x, alleles){
 
     for (hla in (x %>% unique)){
 
-      if (hla == "all") next
+      if (hla %like% "all") next
 
       # match hla allele alelle (end|(not longer allele))
       hla_re <- paste0(hla, "($|[^0-9])")

--- a/R/antigen.garnish_predict.R
+++ b/R/antigen.garnish_predict.R
@@ -443,8 +443,8 @@ check_pred_tools()
 
   # blast first to get pairs for non-mutnfs peptides then run nature paper package
 
-    dt[MHC %like% "H-2", spc := "Ms"] %>%
-      .[MHC %like% "HLA", spc := "Hu"]
+    dt[MHC %like% "H-2" & MHC == "all_mouse", spc := "Ms"] %>%
+      .[MHC %like% "HLA" & MHC == "all_human", spc := "Hu"]
 
   # generate fastas to query
 
@@ -936,13 +936,24 @@ get_pred_commands <- function(dt){
      stop("dt is missing columns")
 
   # replace all with all MHC types
-    dt[MHC == "all", MHC :=
+    dt[MHC == "all_human", MHC :=
     system.file("extdata",
       "all_alleles.txt", package = "antigen.garnish") %>%
        data.table::fread(header = FALSE, sep = "\t") %>%
+       .[V1 %like% "HLA"] %>%
        .$V1 %>%
        paste(collapse = " ")
   ]
+
+  dt[MHC == "all_mouse", MHC :=
+  system.file("extdata",
+    "all_alleles.txt", package = "antigen.garnish") %>%
+     data.table::fread(header = FALSE, sep = "\t") %>%
+     .[V1 %like% "H-2"] %>%
+     .$V1 %>%
+     paste(collapse = " ")
+  ]
+
   if (dt[, MHC %>% unique] %>%
       stringr::str_detect(" ") %>% any) dt %<>%
       tidyr::separate_rows("MHC", sep = " ")
@@ -1375,7 +1386,7 @@ parallel::mcMap(function(x, y) (x %>% as.integer):(y %>% as.integer) %>%
 #'     cDNA_change                 c.718T>A
 #'     MHC                         HLA-A*02:01 HLA-A*03:01
 #'                                 H-2-Kb H-2-Kb
-#'                                 HLA-DRB111:07 [second type]
+#'                                 HLA-DRB1*11:07 [second type]
 #'
 #'
 #'dt with peptide (standard amino-acid one-letter codes only):
@@ -1441,8 +1452,9 @@ parallel::mcMap(function(x, y) (x %>% as.integer):(y %>% as.integer) %>%
 #' * transcript_start
 #' * peptide
 #' @details
-#' * see `list_mhc` for compatible MHC allele syntax
-#' * multiple MHC alleles for a single `sample_id` muar be space separated. Murine and human alleles muat be in separate rows. See [`README` example](http://neoantigens.rech.io.s3-website-us-east-1.amazonaws.com/index.html#predict-neoantigens-from-missense-mutations-insertions-and-deletions).
+#' * see `list_mhc` for compatible MHC allele syntax, you may also use "all_human" or "all_mouse" in the MHC column to use all supported alleles
+#' * multiple MHC alleles for a single `sample_id` must be space separated. Murine and human alleles must be in separate rows. See [`README` example](http://neoantigens.rech.io.s3-website-us-east-1.amazonaws.com/index.html#predict-neoantigens-from-missense-mutations-insertions-and-deletions).
+#' * For species specific proteome-wide DAI to be calculated, run human and murine samples separately
 #' * `garnish_score` is calculated if allelic fraction or tumor cellular fraction were provided
 #'
 #' @seealso \code{\link{garnish_variants}}
@@ -1507,7 +1519,7 @@ parallel::mcMap(function(x, y) (x %>% as.integer):(y %>% as.integer) %>%
 #' }
 #'
 #'\dontrun{
-#'# input a data table of peptides for all MHC types
+#'# input a data table of peptides for all human MHC types
 #'
 #'library(magrittr)
 #'library(data.table)
@@ -1517,7 +1529,7 @@ parallel::mcMap(function(x, y) (x %>% as.integer):(y %>% as.integer) %>%
 #'           sample_id = "test",
 #'           pep_mut = "MTEYKLVVVGAGDVGKSALTIQLIQNHFVDEYDP",
 #'           mutant_index = "12",
-#'           MHC = "all") %>%
+#'           MHC = "all_human") %>%
 #'  garnish_affinity %T>%
 #'  str
 #' }
@@ -1634,9 +1646,9 @@ dt with transcript id:
      sample_id                   sample_1
      ensembl_transcript_id       ENST00000311936
      cDNA_change                 c.718T>A
-     MHC                         HLA-A02:01 HLA-A03:01
+     MHC                         HLA-A*02:01 HLA-A*03:01
                                  H-2-Kb H-2-Kb
-                                 HLA-DRB111:07 [second type]
+                                 HLA-DRB1*11:07 [second type]
 
 
 dt with peptide:
@@ -1887,16 +1899,30 @@ if (generate){
 
         d <- system.file(package = "antigen.garnish") %>% file.path(., "extdata")
 
-          if (dt$MHC %likef% "HLA" %>% any &
-              !dt$MHC %likef% "H-2" %>% any)
+        if (
+            (!dt$MHC %likef% "HLA" %>% any) &
+            (!dt$MHC %likef% "H-2" %>% any) &
+            !all(dt$MHC %chin% c("all_human", "all_mouse"))
+            )
+              stop("MHC do not contain \"HLA-\" or \"H-2\" as a pattern.
+              Alleles must be correctly formatted, see list_mhc().")
+
+          if (
+            (dt$MHC %likef% "HLA" %>% any &
+              !dt$MHC %likef% "H-2" %>% any) ||
+            (dt$MHC == "all_human") %>% any
+            )
               {
                 pepv <-
                 file.path(d,
                   "antigen.garnish_GRCh38_pep.RDS") %>%
                   readRDS(.)
               }
-          if (dt$MHC %likef% "H-2" %>% any &
-              !dt$MHC %likef% "HLA" %>% any)
+          if (
+            (dt$MHC %likef% "H-2" %>% any &
+              !dt$MHC %likef% "HLA" %>% any) ||
+              (dt$MHC == "all_mouse") %>% any
+              )
               {
                 pepv <-
                 file.path(d,
@@ -1906,8 +1932,8 @@ if (generate){
 
           if (
               (dt$MHC %likef% "HLA" %>% any &
-                            dt$MHC %likef% "H-2" %>% any) ||
-              (dt$MHC == "all") %>% any
+                dt$MHC %likef% "H-2" %>% any) ||
+              (any(dt$MHC == "all_human") & any(dt$MHC == "all_mouse"))
               )
               {
                 pepv <- c(

--- a/R/antigen.garnish_predict.R
+++ b/R/antigen.garnish_predict.R
@@ -443,8 +443,8 @@ check_pred_tools()
 
   # blast first to get pairs for non-mutnfs peptides then run nature paper package
 
-    dt[MHC %like% "H-2" & MHC == "all_mouse", spc := "Ms"] %>%
-      .[MHC %like% "HLA" & MHC == "all_human", spc := "Hu"]
+    dt[MHC %like% "H-2" | MHC == "all_mouse", spc := "Ms"] %>%
+      .[MHC %like% "HLA" | MHC == "all_human", spc := "Hu"]
 
   # generate fastas to query
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ library(antigen.garnish)
 
   # add space separated MHC types
   # see list_mhc() for nomenclature of supported alleles
+	# MHC may also be set to "all_human" or "all_mouse" to use all supported alleles
 
       .[, MHC := c("HLA-A*01:47 HLA-A*02:01 HLA-DRB1*14:67")] %>%
 

--- a/man/garnish_affinity.Rd
+++ b/man/garnish_affinity.Rd
@@ -18,7 +18,7 @@ ensembl_transcript_id       ENST00000311936
 cDNA_change                 c.718T>A
 MHC                         HLA-A*02:01 HLA-A*03:01
                             H-2-Kb H-2-Kb
-                            HLA-DRB111:07 [second type]
+                            HLA-DRB1*11:07 [second type]
 }
 
 dt with peptide (standard amino-acid one-letter codes only):\preformatted{Column name                 Example input
@@ -107,8 +107,9 @@ Perform ensemble neoantigen prediction on a data table of missense mutations, in
 }
 \details{
 \itemize{
-\item see \code{list_mhc} for compatible MHC allele syntax
-\item multiple MHC alleles for a single \code{sample_id} muar be space separated. Murine and human alleles muat be in separate rows. See \href{http://neoantigens.rech.io.s3-website-us-east-1.amazonaws.com/index.html#predict-neoantigens-from-missense-mutations-insertions-and-deletions}{README example}.
+\item see \code{list_mhc} for compatible MHC allele syntax, you may also use "all_human" or "all_mouse" in the MHC column to use all supported alleles
+\item multiple MHC alleles for a single \code{sample_id} must be space separated. Murine and human alleles must be in separate rows. See \href{http://neoantigens.rech.io.s3-website-us-east-1.amazonaws.com/index.html#predict-neoantigens-from-missense-mutations-insertions-and-deletions}{README example}.
+\item For species specific proteome-wide DAI to be calculated, run human and murine samples separately
 \item \code{garnish_score} is calculated if allelic fraction or tumor cellular fraction were provided
 }
 }
@@ -170,7 +171,7 @@ library(antigen.garnish)
 }
 
 \dontrun{
-# input a data table of peptides for all MHC types
+# input a data table of peptides for all human MHC types
 
 library(magrittr)
 library(data.table)
@@ -180,7 +181,7 @@ library(antigen.garnish)
           sample_id = "test",
           pep_mut = "MTEYKLVVVGAGDVGKSALTIQLIQNHFVDEYDP",
           mutant_index = "12",
-          MHC = "all") \%>\%
+          MHC = "all_human") \%>\%
  garnish_affinity \%T>\%
  str
 }


### PR DESCRIPTION
* "all" MHC input removed, "all_human" and "all_mouse" are now options
* prevents make_BLAST_uuid bug due to inability to determine species if all entries in the table were "all"
* documentation updates
* Added error message to reduce the chance of the `pepv` error. If all HLA alleles are malformed and species cannot be determined, `garnish_affinity` will stop
* addresses #110 